### PR TITLE
Don't require a value prop for LogOnChange

### DIFF
--- a/src/components/LogOnChange.js
+++ b/src/components/LogOnChange.js
@@ -41,7 +41,7 @@ LogOnChange.propTypes = {
   eventProperties: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   eventType: PropTypes.string.isRequired,
   instanceName: PropTypes.string,
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any,
 };
 
 export default LogOnChange;


### PR DESCRIPTION
Prop types don't have any way to to distinguish between `null` and `undefined`. We'll often want to log a transition to and from a null value.

In my opinion `undefined` should probably be permissible too. If not, there are some alternative solutions proposed here: https://github.com/facebook/prop-types/pull/90