### PR TITLE
Renamed unsafe lifecycle methods

### DIFF
--- a/src/components/Amplitude.js
+++ b/src/components/Amplitude.js
@@ -47,7 +47,7 @@ class Amplitude extends React.Component {
     };
   });
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { props } = this;
 
     if (typeof nextProps.debounceInterval === 'number') {

--- a/src/components/AmplitudeProvider.js
+++ b/src/components/AmplitudeProvider.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { isValidAmplitudeInstance } from '../lib/validation';
 
 class AmplitudeProvider extends React.Component {
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { props } = this;
 
     if (isValidAmplitudeInstance(props.amplitudeInstance)) {


### PR DESCRIPTION
componentWillMount and componentWillReceiveProps have been changed. 
In React 17.x, only the UNSAFE_ name will work. 

In the future, you can use componentDidMount instead of componentWillMount and componentDidUpdate instead of componentWillReceiveProps. 